### PR TITLE
升级 Skill 以对齐新版 OpenAPI 契约

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ curl -sL https://raw.githubusercontent.com/iswalle/getnote-openclaw/main/package
         "apiKey": "gk_live_xxx",
         "env": {
           "GETNOTE_CLIENT_ID": "cli_xxx",
-          "GETNOTE_OWNER_ID": "ou_xxx"
+          "GETNOTE_OWNER_ID": "ou_xxx",
+          "GETNOTE_API_URL": "https://openapi.biji.com"
         }
       }
     }
@@ -138,6 +139,8 @@ curl -sL https://raw.githubusercontent.com/iswalle/getnote-openclaw/main/package
 ```
 
 > 💡 `GETNOTE_OWNER_ID` 可选，配置后只有你能操作笔记（群聊安全）
+
+> 💡 `GETNOTE_API_URL` 可选，仅在明确联调测试环境时覆盖；默认无需配置
 
 > 💡 需要 [Get笔记会员](https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye) 才能使用 API
 
@@ -167,6 +170,12 @@ curl -sL https://raw.githubusercontent.com/iswalle/getnote-openclaw/main/package
 | `class_audio` | 课堂录音 | 📖 仅读取 |
 | `recorder_audio` | 录音卡长录 | 📖 仅读取 |
 | `recorder_flash_audio` | 录音卡闪念 | 📖 仅读取 |
+
+创建笔记支持：
+
+- 指定 `topic_id`，直接存入普通（DEFAULT）、书籍（BOOKSPACE）或客户档案（CUSTOMER）知识库
+- 指定字符串 `parent_id` 创建子笔记
+- 指定 `client_request_id` 或 `Idempotency-Key`，避免网络重试重复创建
 
 > 💡 语音类笔记可读取 AI 摘要和转写原文，需调用详情接口获取。
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ curl -sL https://raw.githubusercontent.com/iswalle/getnote-openclaw/main/package
 
 > 💡 `GETNOTE_API_URL` 可选，仅在明确联调测试环境时覆盖；默认无需配置
 
-> 💡 需要 [Get笔记会员](https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye) 才能使用 API
+> 💡 需要 [Get笔记会员](https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=openapi_skill) 才能使用 API
 
 ---
 
@@ -225,7 +225,7 @@ curl -sL https://raw.githubusercontent.com/iswalle/getnote-openclaw/main/package
 - [Get笔记官网](https://biji.com)
 - [开放平台](https://www.biji.com/openapi)
 - [ClawHub](https://clawhub.ai/iswalle/getnote)
-- [开通会员](https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye)
+- [开通会员](https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=openapi_skill)
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,9 +17,9 @@ metadata: {"openclaw": {"requires": {}, "optionalEnv": ["GETNOTE_API_KEY", "GETN
 
 ### 🌐 Base URL
 ```
-https://openapi.biji.com
+${GETNOTE_API_URL:-https://openapi.biji.com}
 ```
-所有 API 请求必须使用此 Base URL，不要使用 `biji.com` 或其他地址。
+默认使用 `https://openapi.biji.com`。仅在用户或运行环境明确配置 `GETNOTE_API_URL` 时使用覆盖值；不要把网页域名 `biji.com` 当成 API 地址。
 
 ### 🔑 认证
 请求头：
@@ -35,7 +35,9 @@ Scope 权限：`note.content.read`（读取）、`note.content.write`（写入�
 
 **正确做法**：始终把 ID 当字符串处理，在 `JSON.parse` 之前替换：
 ```javascript
-const safe = text.replace(/"(id|note_id|parent_id|follow_id|live_id)"\s*:\s*(\d+)/g, '"$1":"$2"');
+const safe = text
+  .replace(/"(id|note_id|parent_id|follow_id|live_id|next_cursor)"\s*:\s*(\d{16,})/g, '"$1":"$2"')
+  .replace(/([:[,]\s*)(-?\d{16,})(?=\s*[,}\]])/g, '$1"$2"');
 // 注：next_cursor 已不需要处理，翻页请直接使用响应中的 cursor（string）字段
 const data = JSON.parse(safe);
 ```
@@ -52,6 +54,7 @@ Python / Go 等语言原生支持大整数，无此问题。
 - **禁止跳过轮询**：链接/图片笔记返回 `task_id` 后，**必须**轮询 `/task/progress` 直到 `success` 或 `failed`，不得假设任务已完成
 - **禁止伪造 API 响应**：不得在未实际调用 API 的情况下告诉用户「已保存」「已删除」
 - **禁止忽略错误码**：API 返回 `success: false` 时必须处理，不得静默吞掉
+- **禁止只看 HTTP 状态码**：即使 HTTP 为 200，只要 `success: false` 就是失败；优先依据 `error.reason` 和 `error.retryable` 决定是否重试
 - **禁止混淆内链和分享链接**：`biji.com/note/{id}` 是内链（仅笔记主人可见），`share_note/{id}` 是分享链接（公开可访问），两者不可互换
 
 ### 🔄 失败重试策略
@@ -179,9 +182,13 @@ Python / Go 等语言原生支持大整数，无此问题。
 {
   "success": false,
   "error": {
-    "code": 10001,
-    "message": "unauthorized",
-    "reason": "not_member"
+    "code": 10000,
+    "message": "参数错误",
+    "reason": "invalid_request",
+    "retryable": false,
+    "field": "parent_id",
+    "constraint": "non_negative_decimal_integer",
+    "expected_type": "decimal string or JSON integer"
   },
   "request_id": "xxx"
 }
@@ -190,8 +197,12 @@ Python / Go 等语言原生支持大整数，无此问题。
 | 错误码 | 说明 | 处理方式 |
 |--------|------|---------|
 | 10000 | 参数错误 | 检查请求参数 |
-| 10001 | 鉴权失败 | 检查 API Key 和 Client ID，或重新授权 |
-| 10100 | 数据不存在 | 确认笔记/知识库 ID 正确 |
+| 10004 | 未授权 | 检查 API Key 和 Client ID，或重新授权 |
+| 10100 | 通用数据不存在 | 确认资源 ID 正确 |
+| 10500 | 笔记不存在 | 确认 note_id 正确，禁止编造 ID |
+| 10502 | 幂等键冲突 | 同一个键只能对应完全相同的请求 |
+| 10503 | 相同请求处理中 | 保持请求不变，稍后使用同一幂等键重试 |
+| 10504 | 幂等服务暂不可用 | 保持请求不变，稍后使用同一幂等键重试 |
 | 10201 | 非会员 | 引导开通：https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye |
 | 10202 | QPS 限流 | 降低频率，查看 rate_limit 字段 |
 | 30000 | 服务调用失败 | 稍后重试 |

--- a/SKILL.md
+++ b/SKILL.md
@@ -46,7 +46,7 @@ Python / Go 等语言原生支持大整数，无此问题。
 ### 🔒 安全规则
 - 笔记数据属于用户隐私，不在群聊中主动展示笔记内容
 - 若配置了 `GETNOTE_OWNER_ID`，检查 sender_id 是否匹配；不匹配时回复「抱歉，笔记是私密的，我无法操作」
-- API 返回 `error.reason: "not_member"` 或错误码 `10201` 时，引导开通会员：https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye
+- API 返回 `error.reason: "not_member"` 或错误码 `10201` 时，引导开通会员：https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=openapi_skill
 - 创建笔记建议间隔 1 分钟以上，避免触发限流
 
 ### 🚫 反幻觉边界（严格禁止）
@@ -203,7 +203,7 @@ Python / Go 等语言原生支持大整数，无此问题。
 | 10502 | 幂等键冲突 | 同一个键只能对应完全相同的请求 |
 | 10503 | 相同请求处理中 | 保持请求不变，稍后使用同一幂等键重试 |
 | 10504 | 幂等服务暂不可用 | 保持请求不变，稍后使用同一幂等键重试 |
-| 10201 | 非会员 | 引导开通：https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye |
+| 10201 | 非会员 | 引导开通：https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=openapi_skill |
 | 10202 | QPS 限流 | 降低频率，查看 rate_limit 字段 |
 | 30000 | 服务调用失败 | 稍后重试 |
 | 50000 | 系统错误 | 稍后重试 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "getnote",
-  "version": "1.8.9",
+  "version": "1.9.0",
   "description": "Get笔记 Skill — 保存链接/图片/文本到笔记，语义搜索，知识库管理。说「记一下」就能存，说「搜一下」就能找。",
   "license": "MIT-0",
   "author": "get-notes@luojilab.com",

--- a/references/api-details.md
+++ b/references/api-details.md
@@ -35,7 +35,7 @@
 
 | reason | 说明 |
 |--------|------|
-| not_member | 非会员，引导开通：https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=wangye |
+| not_member | 非会员，引导开通：https://www.biji.com/checkout?product_alias=9Ab36BB3ZD&spm=openapi_skill |
 | qps_global | 全局 QPS 超限 |
 | qps_bucket | 桶级 QPS 超限 |
 | quota_day | 当日配额用尽 |

--- a/references/api-details.md
+++ b/references/api-details.md
@@ -16,10 +16,15 @@
 | 错误码 | 说明 |
 |--------|------|
 | 10000 | 参数错误 |
-| 10001 | 鉴权失败 |
-| 10100 | 数据不存在（笔记不存在等）|
+| 10004 | 未授权 / API Key 无效 |
+| 10100 | 通用数据不存在 |
 | 10201 | 非会员 |
 | 10202 | QPS 限流 |
+| 10500 | 笔记不存在 |
+| 10501 | 请求参数错误 |
+| 10502 | 幂等键已用于不同请求 |
+| 10503 | 相同幂等请求正在处理 |
+| 10504 | 幂等服务暂不可用 |
 | 30000 | 服务调用失败 |
 | 42900 | 配额限流 |
 | 50000 | 系统错误 |
@@ -35,6 +40,21 @@
 | qps_bucket | 桶级 QPS 超限 |
 | quota_day | 当日配额用尽 |
 | quota_month | 当月配额用尽 |
+| note_not_found | 笔记不存在 |
+| invalid_request | 参数或字段约束不满足 |
+| idempotency_conflict | 幂等键已绑定另一份请求，必须更换键或恢复原请求 |
+| idempotency_in_progress | 同一请求处理中，可稍后原样重试 |
+| idempotency_unavailable | 幂等服务暂不可用，可稍后原样重试 |
+
+失败响应仍可能使用 HTTP 200，必须检查 `success`。`error` 保留历史 `code/message`，并新增：
+
+| 字段 | 说明 |
+|---|---|
+| `reason` | 稳定的机器可读原因，程序应优先判断它 |
+| `retryable` | 是否可在不修改请求的情况下安全重试 |
+| `field` | 可安全识别时返回的错误字段 |
+| `constraint` | 稳定的字段约束 |
+| `expected_type` | 推荐输入类型或格式 |
 
 ---
 
@@ -103,7 +123,9 @@
 | `content` | string | 否 | Markdown 格式正文 |
 | `note_type` | string | 否 | 笔记类型，默认 `plain_text`：<br>• `plain_text` - 纯文本（同步）<br>• `link` - 链接笔记：分享链接（`biji.com/note/share_note/*` 或 `d.biji.com/*`）同步直接返回 `note_id`；普通链接异步，需轮询<br>• `img_text` - 图片笔记（异步，须轮询） |
 | `tags` | string[] | 否 | 标签名称列表 |
-| `parent_id` | int64 | 否 | 父笔记 ID，创建子笔记时填写，默认 0 |
+| `topic_id` | string | 否 | 目标知识库 ID，支持 DEFAULT / BOOKSPACE / CUSTOMER 三类自有知识库 |
+| `parent_id` | decimal string 或 JSON integer | 否 | 父笔记 ID，推荐十进制字符串；创建子笔记时填写，可在同一父笔记下创建多篇 |
+| `client_request_id` | string | 否 | 幂等键（1-128 ASCII 字符）；也可使用 `Idempotency-Key` 请求头 |
 | `link_url` | string | link 类型必填 | 要保存的链接 URL |
 | `image_urls` | string[] | img_text 类型必填 | 图片访问地址列表，使用上传凭证中的 `access_url` |
 
@@ -152,6 +174,9 @@
 | note.content.trash | 笔记移入回收站 |
 | topic.blogger.read | 获取知识库订阅博主 |
 | topic.live.read | 获取知识库订阅直播 |
+| topic.live.write | 订阅直播到知识库 |
+| note.sharing.write | 设置笔记公开分享 |
+| note.recorder.read | 读取企业录音卡笔记（仅企业代授权） |
 
 ---
 

--- a/references/knowledge.md
+++ b/references/knowledge.md
@@ -15,7 +15,15 @@ GET https://openapi.biji.com/open/api/v1/resource/knowledge/list?page=1
 参数：
 - `page`: 页码，从 1 开始，默认 1（固定每页 20 条）
 
-返回：`topics[]`、`has_more`、`total`
+返回：`topics[]`、`has_more`、`total`。该列表包含用户拥有的三类知识库：
+
+| scope | 含义 | 保存笔记时是否可作为 topic_id |
+|---|---|---|
+| `DEFAULT` | 普通知识库 | 是 |
+| `BOOKSPACE` | 书籍知识库 | 是 |
+| `CUSTOMER` | 客户档案 | 是 |
+
+当用户说“存到某个知识库”时，先拉取完整列表并按 `name` 与 `scope` 确认目标，再把对应 `topic_id` 放入 `/note/save`；不要只过滤 `DEFAULT`。
 
 每个 topic 包含：
 - `topic_id`：知识库 ID（字符串，后续所有操作接口的 `topic_id` 参数均传此值）

--- a/references/list.md
+++ b/references/list.md
@@ -181,7 +181,7 @@ Content-Type: application/json
 
 ## 笔记分享
 
-生成笔记的公开分享链接，需要 `note.content.read` scope。
+生成笔记的公开分享链接，需要 `note.sharing.write` scope。
 
 ```
 POST https://openapi.biji.com/open/api/v1/resource/note/sharing

--- a/references/save.md
+++ b/references/save.md
@@ -24,18 +24,25 @@ Content-Type: application/json
   "content": "Markdown 内容",
   "note_type": "plain_text",
   "tags": ["标签1", "标签2"],
-  "parent_id": 0,
+  "topic_id": "QYADXzWn",
+  "parent_id": "1916020531058082912",
+  "client_request_id": "agent-session-42-save-1",
   "link_url": "https://...",
   "image_urls": ["https://..."]
 }
 ```
+
+- `topic_id`：可选，直接把新笔记加入目标知识库；先调用知识库列表并按 `name` / `scope` 选择
+- `parent_id`：可选，必须优先传十进制字符串；用于创建子笔记，同一父笔记可以创建多篇子笔记
+- `client_request_id`：可选幂等键（1-128 个 ASCII 字符）；网络重试时复用同一个值，不得重新生成
+- 也可用 `Idempotency-Key` 请求头传幂等键。若 Header 与 Body 同时传，二者必须完全相同
 
 详细字段说明见 [api-details.md](api-details.md#新建笔记字段说明)。
 
 - `plain_text`：同步返回，立即完成，响应中包含 `note_id`（字符串）
 - `link`（**分享链接**）：若 `link_url` 为 `biji.com/note/share_note/*` 或 `d.biji.com/*` 短链，**同步返回**，响应中直接包含 `note_id`、`title`、`created_at`、`updated_at`，**无需轮询**
 - `link`（**普通链接**）：返回 `task_id`，**必须轮询** `/task/progress`
-- `img_text`：返回 `task_id`，**必须轮询** `/task/progress`
+- `img_text`：返回 `data.tasks[0].task_id`，**必须轮询** `/task/progress`
 
 ---
 
@@ -54,7 +61,7 @@ Content-Type: application/json
 返回：
 - `status`: `pending` | `processing` | `success` | `failed`
 - `note_id`: 成功时返回笔记 ID（**字符串**）；任务进行中时值为 `"0"`，需过滤
-- `error_msg`: 失败时返回错误信息
+- `error_msg`: 仅 `failed` 时返回错误信息；`pending` / `processing` / `success` 不应据此判断失败
 
 **建议 10-30 秒间隔轮询，直到 success 或 failed**。
 
@@ -156,7 +163,7 @@ GET https://openapi.biji.com/open/api/v1/resource/image/upload_token?mime_type=j
 ```
 POST https://openapi.biji.com/open/api/v1/resource/note/save {note_type:"img_text", image_urls:[access_url]}
 ```
-拿到 task_id 后，**立即发消息给用户**：
+从 `data.tasks[0].task_id` 取任务 ID，**立即发消息给用户**：
 > ✅ 图片已保存，正在识别内容，稍后告诉你结果...
 
 **步骤 4**：后台轮询

--- a/scripts/oauth_poll.py
+++ b/scripts/oauth_poll.py
@@ -31,8 +31,18 @@ import time
 import json
 import urllib.request
 import urllib.error
+import os
 
-API_URL = "https://openapi.biji.com/open/api/v1/oauth/token"
+def oauth_token_url() -> str:
+    base = os.environ.get("GETNOTE_API_URL", "https://openapi.biji.com").rstrip("/")
+    if base.endswith("/open/api/v1"):
+        return f"{base}/oauth/token"
+    if base.endswith("/open"):
+        return f"{base}/api/v1/oauth/token"
+    return f"{base}/open/api/v1/oauth/token"
+
+
+API_URL = oauth_token_url()
 DEFAULT_CLIENT_ID = "cli_a1b2c3d4e5f6789012345678abcdef90"
 INTERVAL = 5       # 轮询间隔（秒）
 MAX_ATTEMPTS = 120 # 最大尝试次数（5秒 * 120 = 10分钟）

--- a/scripts/upload_image.py
+++ b/scripts/upload_image.py
@@ -28,7 +28,19 @@ except ImportError:
     sys.exit(1)
 
 
-BASE_URL = "https://openapi.biji.com/open/api/v1/resource"
+def resource_base_url() -> str:
+    """Resolve production or explicitly overridden OpenAPI resource base."""
+    base = os.environ.get("GETNOTE_API_URL", "https://openapi.biji.com").rstrip("/")
+    if base.endswith("/open/api/v1/resource"):
+        return base
+    if base.endswith("/open/api/v1"):
+        return f"{base}/resource"
+    if base.endswith("/open"):
+        return f"{base}/api/v1/resource"
+    return f"{base}/open/api/v1/resource"
+
+
+BASE_URL = resource_base_url()
 DEFAULT_CLIENT_ID = "cli_a1b2c3d4e5f6789012345678abcdef90"
 
 
@@ -174,10 +186,11 @@ def main():
         print(f"访问 URL: {image_url}")
         print()
         print("💡 创建图片笔记:")
-        print(f'   curl -X POST "https://openapi.biji.com/open/api/v1/resource/note/save?task_id=..."')
+        print(f'   curl -X POST "{BASE_URL}/note/save"')
         print(f'     -H "Authorization: $GETNOTE_API_KEY"')
+        print(f'     -H "X-Client-ID: $GETNOTE_CLIENT_ID"')
         print(f'     -H "Content-Type: application/json"')
-        print(f'     -d \'{{"type":"img_text","image_urls":["{image_url}"]}}\'')
+        print(f'     -d \'{{"note_type":"img_text","image_urls":["{image_url}"],"client_request_id":"replace-with-stable-request-id"}}\'')
         
     except Exception as e:
         print(f"错误: {e}")


### PR DESCRIPTION
## 改动内容

- 增加测试环境 Base URL 覆盖能力
- 对齐雪花 ID、结构化错误、幂等和异步任务规范
- 保存笔记支持知识库和父笔记
- 补全 17 个 Scope，并修正分享、直播和图片上传示例
- 明确三类知识库的返回和选择方式
- 会员购买入口使用 `openapi_skill` 专属渠道

## 兼容策略

保留现有 Skill 名称和安装方式，不破坏历史 OpenClaw 安装。

## 验证

- Python 脚本语法检查通过
- 新版 API 契约关键字段检查通过
- 图片上传脚本已在新版 OpenAPI 环境完成 OSS 实调
- CLI 内置 Skill 与独立 Skill 的契约已对齐

## 发布计划

合并后发布 `v1.9.0`，同步更新 GitHub 与 ClawHub。