### PR TITLE
修正 Skill 2.0 安装包下载入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ AI 会自动安装官方 CLI 并引导授权。需要登录时，只在打开的
 
 ### 方式二：下载 Skill 安装包
 
-下载 [得到大脑 Skill 2.0 安装包](https://github.com/iswalle/getnote-openclaw/releases/latest/download/getnote-skill.zip)，直接拖进 AI 的聊天框，然后说：
+打开 [得到大脑 Skill 发布页](https://github.com/iswalle/getnote-openclaw/releases/latest)，在最新版的 Assets 中下载 `getnote-skill.zip`，直接拖进 AI 的聊天框，然后说：
 
 > 请解压并安装这个得到大脑 Skill，按照 SKILL.md 自动安装官方 CLI，引导我完成授权，并读取最近一条笔记确认可以正常使用。
 

--- a/scripts/verify_cli_contract.py
+++ b/scripts/verify_cli_contract.py
@@ -193,7 +193,7 @@ if readme.count("### 方式") != 2:
     fail("README must expose exactly two installation methods")
 for required in (
     "https://github.com/iswalle/getnote-openclaw",
-    "https://github.com/iswalle/getnote-openclaw/releases/latest/download/getnote-skill.zip",
+    "https://github.com/iswalle/getnote-openclaw/releases/latest",
     "不会清除已经保存的授权凭证",
     "**v2.0.0**",
 ):


### PR DESCRIPTION
## 改动说明

- README 下载入口改为稳定的 GitHub Releases 最新版本页面
- 用户在 Assets 中下载 `getnote-skill.zip`
- 同步更新契约校验，避免再次写回容易失效的直链

## 验证

- CLI contract 2.1 校验通过
- Skill 2.0 安装包重新构建通过
- README 核心能力和历史更新日志格式保持不变

WIP：待 CI 通过后合并，并创建 v2.0.0 Release。