### PR TITLE
统一 Skill 2.0 发布包与下载说明

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Validate packaged Skill structure
         run: |
           python3 scripts/build_skill_package.py
-          unzip -Z1 dist/getnote-skill.zip | sed 's#^getnote-skill/##' | sed '/^$/d; /\/$/d' | sort > /tmp/package-files.txt
+          unzip -Z1 dist/getnote-skill-2.0.0.zip | sed 's#^getnote-skill/##' | sed '/^$/d; /\/$/d' | sort > /tmp/package-files.txt
           test "$(cat /tmp/package-files.txt)" = $'SKILL.md\nreferences/auth.md\nreferences/kb.md\nreferences/note.md\nreferences/search.md\nreferences/tag.md\nscripts/install.sh'

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ AI 会自动安装官方 CLI 并引导授权。需要登录时，只在打开的
 
 ### 方式二：下载 Skill 安装包
 
-打开 [得到大脑 Skill 发布页](https://github.com/iswalle/getnote-openclaw/releases/latest)，在最新版的 Assets 中下载 `getnote-skill.zip`，直接拖进 AI 的聊天框，然后说：
+打开 [得到大脑 Skill 发布页](https://github.com/iswalle/getnote-openclaw/releases/latest)，在最新版的 Assets 中下载 `getnote-skill-2.0.0.zip`，直接拖进 AI 的聊天框，然后说：
 
 > 请解压并安装这个得到大脑 Skill，按照 SKILL.md 自动安装官方 CLI，引导我完成授权，并读取最近一条笔记确认可以正常使用。
 

--- a/scripts/build_skill_package.py
+++ b/scripts/build_skill_package.py
@@ -15,8 +15,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DIST = ROOT / "dist"
 STAGE = DIST / "getnote-skill"
-ARCHIVE = DIST / "getnote-skill.zip"
 VERSION = "2.0.0"
+ARCHIVE = DIST / f"getnote-skill-{VERSION}.zip"
+LEGACY_ARCHIVE = DIST / "getnote-skill.zip"
 
 
 def main() -> int:
@@ -32,15 +33,12 @@ def main() -> int:
     runtime_scripts.mkdir()
     shutil.copy2(ROOT / "scripts" / "install.sh", runtime_scripts / "install.sh")
 
+    if LEGACY_ARCHIVE.exists():
+        LEGACY_ARCHIVE.unlink()
     if ARCHIVE.exists():
         ARCHIVE.unlink()
     shutil.make_archive(str(ARCHIVE.with_suffix("")), "zip", DIST, STAGE.name)
-    versioned_archive = DIST / f"getnote-skill-{VERSION}.zip"
-    if versioned_archive.exists():
-        versioned_archive.unlink()
-    shutil.copy2(ARCHIVE, versioned_archive)
     print(ARCHIVE)
-    print(versioned_archive)
     return 0
 
 

--- a/scripts/verify_cli_contract.py
+++ b/scripts/verify_cli_contract.py
@@ -194,6 +194,7 @@ if readme.count("### 方式") != 2:
 for required in (
     "https://github.com/iswalle/getnote-openclaw",
     "https://github.com/iswalle/getnote-openclaw/releases/latest",
+    "getnote-skill-2.0.0.zip",
     "不会清除已经保存的授权凭证",
     "**v2.0.0**",
 ):
@@ -203,8 +204,10 @@ for required in (
 builder_text = (ROOT / "scripts" / "build_skill_package.py").read_text(encoding="utf-8")
 if 'ROOT / "README.md"' in builder_text:
     fail("uploadable Skill archive must contain runtime Skill files only")
-if 'f"getnote-skill-{VERSION}.zip"' not in builder_text:
+if 'ARCHIVE = DIST / f"getnote-skill-{VERSION}.zip"' not in builder_text:
     fail("builder must create a versioned Skill package")
+if 'shutil.copy2(ARCHIVE, versioned_archive)' in builder_text:
+    fail("builder must not create duplicate stable and versioned packages")
 
 mentioned: set[str] = set()
 for reference_path in DOMAIN_REFERENCES:


### PR DESCRIPTION
## 改动说明

- Release 仅保留 `getnote-skill-2.0.0.zip` 一个安装包
- README 下载说明与实际资产名称保持一致
- 打包脚本不再生成内容重复的稳定包
- CI 改为校验唯一的版本安装包

## 验证

- CLI contract 2.1 校验通过
- 安装包结构校验通过
- README 核心能力和历史更新日志未修改

WIP：待 CI 通过后合并并修正 v2.0.0 Release。